### PR TITLE
Fix login redirection and improve authentication handling

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -14,7 +14,7 @@ export default function RootLayout({
 }>) {
     return (
         <html lang="en">
-        <body className="antialiased">
+        <body className="antialiased" suppressHydrationWarning>
         <AuthProvider>
             {children}
         </AuthProvider>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -37,24 +37,13 @@ export default function Home() {
     const [selectedEquipment, setSelectedEquipment] = useState<Set<number>>(new Set());
     const [quantities, setQuantities] = useState<Map<number, number>>(new Map());
     const [isLoading, setIsLoading] = useState(false);
-    const [redirecting, setRedirecting] = useState(false);
 
     // Check authentication and redirect if not authenticated
     useEffect(() => {
-        let isMounted = true;
-        if (!isAuthenticated && !redirecting) {
-            setRedirecting(true);
-            // Await router.push and cleanup if unmounted
-            Promise.resolve(router.push('/login')).finally(() => {
-                if (!isMounted) {
-                    setRedirecting(false);
-                }
-            });
+        if (!isAuthenticated) {
+            router.push('/login');
         }
-        return () => {
-            isMounted = false;
-        };
-    }, [isAuthenticated, redirecting, router]);
+    }, [isAuthenticated, router]);
 
     // --- Utility Fetch Function ---
     // Memoize the function for use in useEffect dependencies
@@ -187,8 +176,8 @@ export default function Home() {
                         disabled={isLoading && schools.length === 0}
                     />
 
+                    {/* Grade Selector - Enabled after School is selected */}
                     {grades.length > 0 && (
-                        {/* Grade Selector - Enabled after School is selected */}
                         <SearchableSelect
                             label="Grade"
                             items={grades}
@@ -198,8 +187,8 @@ export default function Home() {
                         />
                     )}
 
+                    {/* Class Selector - Enabled after Grade is selected */}
                     {classes.length > 0 && (
-                        {/* Class Selector - Enabled after Grade is selected */}
                         <SearchableSelect
                             label="Class"
                             items={classes}

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -11,17 +11,15 @@ interface AuthContextType {
 const AuthContext = createContext<AuthContextType | undefined>(undefined);
 
 export function AuthProvider({children}: { children: ReactNode }) {
-    const [isAuthenticated, setIsAuthenticated] = useState(() => {
-        // Check sessionStorage on initialization (only runs once on mount)
-        if (typeof window !== 'undefined') {
-            return sessionStorage.getItem('isAuthenticated') === 'true';
-        }
-        return false;
-    });
+    // Always start with false to match SSR, then update after hydration
+    const [isAuthenticated, setIsAuthenticated] = useState(false);
     const [isLoading, setIsLoading] = useState(true);
 
     useEffect(() => {
-        // Mark as loaded after hydration
+        // Check sessionStorage only after hydration to avoid SSR mismatch
+        const storedAuth = sessionStorage.getItem('isAuthenticated') === 'true';
+        // eslint-disable-next-line react-hooks/set-state-in-effect
+        setIsAuthenticated(storedAuth);
         setIsLoading(false);
     }, []);
 


### PR DESCRIPTION
This pull request focuses on improving authentication state handling and fixing SSR/CSR mismatches in the app. The main changes ensure that authentication status is determined only after hydration, preventing UI inconsistencies between server-side and client-side rendering. Additionally, some UI logic and redirection flows have been simplified.

**Authentication and SSR/CSR Handling:**

* Changed the initial value of `isAuthenticated` in `AuthProvider` (`src/contexts/AuthContext.tsx`) to always start as `false`, then update after hydration, ensuring consistency between SSR and CSR. The session storage check now happens only after hydration.
* Added `suppressHydrationWarning` to the `<body>` element in `RootLayout` (`src/app/layout.tsx`) to prevent hydration mismatch warnings in React.

**Authentication Redirect Logic:**

* Simplified authentication redirect in `Home` (`src/app/page.tsx`): removed unnecessary `redirecting` state and mount checks, now directly pushes to `/login` if not authenticated.

**UI Rendering Logic:**

* Fixed conditional rendering of the grade selector in `Home` by correcting misplaced comments and ensuring the selector only appears when grades are available.
* Fixed conditional rendering of the class selector in `Home` similarly, ensuring it only appears when classes are available.