### PR TITLE
Stringify ids in api.ts

### DIFF
--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -74,10 +74,26 @@ export async function getCart(userid: string) {
 }
 
 export async function updateCart(userid: string, items: CartEntryPayload[]) {
+    // Ensure all item ids in items[].items are strings before sending
+    const itemsWithStringIds = items.map(entry => ({
+        ...entry,
+        school: {
+            ...entry.school,
+            id: String(entry.school.id)
+        },
+        grade: {
+            ...entry.grade,
+            id: String(entry.grade.id)
+        },
+        items: entry.items.map(item => ({
+            ...item,
+            id: String(item.id)
+        }))
+    }));
     const res = await fetch(`${API_BASE}/api/cart?userid=${encodeURIComponent(userid)}`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(items),
+        body: JSON.stringify(itemsWithStringIds),
         credentials: 'include',
     });
     if (!res.ok) return parseError(res, 'Failed to update cart');


### PR DESCRIPTION
This pull request updates the `updateCart` function in `src/services/api.ts` to ensure that all `id` fields for schools, grades, and items in the cart payload are converted to strings before sending the data to the API. This helps maintain consistency in data types and prevents potential issues with the backend expecting string IDs.

**Data normalization:**

* Modified the `updateCart` function to convert all `id` fields in `school`, `grade`, and `items` within each cart entry to strings before sending the payload to the API.